### PR TITLE
Adjusted flake to use system zsh config. Added OCaml LSP to flake.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,10 +65,15 @@
         packages = [
           darwinPkgs.ocaml
           darwinPkgs.dune_3
+          darwinPkgs.ocamlPackages.ocaml-lsp
+          darwinPkgs.zsh
         ];
         inputsFrom = [ darwinSccPkg ];
         shellHook = ''
-          echo "Entered SCC OCaml development environment for aarch64-darwin."
+          echo "Entering SCC OCaml development environment for aarch64-darwin."
+          export PATH=${darwinPkgs.zsh}/bin:$PATH
+          export SHELL=${darwinPkgs.zsh}/bin/zsh
+          exec ${darwinPkgs.zsh}/bin/zsh --login
         '';
       };
 


### PR DESCRIPTION
`nix develop` now launches a zsh shell with the local config applied. Under the (true) assumption we are all using zsh.

OCaml LSP added to flake. Verified with `hx --health ocaml`.